### PR TITLE
using abs to remove negative value of key

### DIFF
--- a/gmsh2dagmc/dagmc.py
+++ b/gmsh2dagmc/dagmc.py
@@ -116,7 +116,11 @@ class dagmcGeom:
     def make_topology(self):
         # loop over the surfaces
         for surf in self.pygmsh.sense_data.keys():
-            surface_id = surf[1]
+            # surface_id = surf[1]
+            # the line above crashed the code as it would return negative
+            # numbers that don't exist in the dictionary. abs() has been added
+            # which needs checking to see if it is valid
+            surface_id = abs(surf[1])
             surf_handle = self.moab_gmsh_surfs[surface_id]
             # for each volume
             for vol in self.pygmsh.sense_data[surf]:


### PR DESCRIPTION
The ```surface_id = surf[1]``` was returning -3 value which was causing a keyerror when used in the ```self.pygmsh.sense_data[surf]``` line.

To fix this I've used the ```abs``` to make sure it is always positive.

What do you think  @makeclean is this a safe opperation?
